### PR TITLE
Improve release workflow

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -67,12 +67,14 @@ namespace :release do
       sh "git push --set-upstream origin #{release_branch}"
 
       # Waiting for CI to finish
-      sh "git checkout #{initial_branch}"
       puts 'Waiting for CI to finish'
-      sleep 5 until ci_status(initial_branch) == 'success'
+      sleep 5 until ci_status(release_branch) == 'success'
 
       # Merge release branch
+      sh "git checkout #{initial_branch}"
       sh "git merge --gpg-sign --no-ff --message 'Release v#{release}' #{release_branch}"
+
+      # Tag release
       sh "git tag --sign v#{release} --message 'Release v#{release}'"
       sh 'git push --follow-tags'
     end

--- a/Rakefile
+++ b/Rakefile
@@ -50,7 +50,7 @@ namespace :release do
     task level.to_sym do
       v = increment_version(level)
       release = "#{v[:major]}.#{v[:minor]}.#{v[:patch]}"
-      release_branch = "release_v#{release}"
+      release_branch = "release_v#{release.gsub(/[^0-9A-Za-z]/, '_')}"
       initial_branch = git_branch
 
       # Create a new release branch


### PR DESCRIPTION
- Wait for the status of the newly created branch not master
- Sanitize release branch name